### PR TITLE
update ambassador.sh to include port

### DIFF
--- a/5 - Service Accounts/ambassador.sh
+++ b/5 - Service Accounts/ambassador.sh
@@ -2,4 +2,4 @@
 CRT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 REMOTE_API="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
 TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-/usr/local/bin/kubectl proxy --server="$REMOTE_API" --certificate-authority="$CRT" --token="$TOKEN" --accept-paths='^.*'
+/usr/local/bin/kubectl proxy --server="$REMOTE_API" --certificate-authority="$CRT" --token="$TOKEN" --accept-paths='^.*' --port=8001


### PR DESCRIPTION
I had some trouble to understand at:

Securing Apps with Service Accounts - Working with Service Accounts - 3:54

"The binding of the kubectl proxy process to the port 8001 to the local host."

Where did the port number 8001 come from?

I figured out that this port is the default port for the kubectl proxy command as described here:
https://kubernetes.io/docs/...

Maybe change the ambassador.sh file to include port: